### PR TITLE
[codex] Improve admin blob efficiency and cache invalidation

### DIFF
--- a/src/app/api/admin/events/route.ts
+++ b/src/app/api/admin/events/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
-import { getAdminEvents, addAdminEvent, deleteAdminEvent, excludeEventOccurrence } from '@/lib/blob-store';
+import {
+  getAdminEvents,
+  addAdminEvent,
+  deleteAdminEvent,
+  excludeEventOccurrence,
+  invalidateAdminEventsCache,
+} from '@/lib/blob-store';
 import type { AdminEvent, AdminEventFormData } from '@/types/admin';
 import type { RecurrenceFrequency } from '@/types/admin';
 import { slugify } from '@/lib/utils';
@@ -80,6 +86,7 @@ export async function POST(request: Request) {
     };
 
     await addAdminEvent(event);
+    invalidateAdminEventsCache();
     revalidatePath('/calendar');
     revalidatePath('/events');
     return NextResponse.json(event, { status: 201 });
@@ -102,6 +109,7 @@ export async function DELETE(request: Request) {
     } else {
       await deleteAdminEvent(id);
     }
+    invalidateAdminEventsCache();
     revalidatePath('/calendar');
     revalidatePath('/events');
     return NextResponse.json({ success: true });

--- a/src/app/api/admin/events/route.ts
+++ b/src/app/api/admin/events/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import { getAdminEvents, addAdminEvent, deleteAdminEvent, excludeEventOccurrence } from '@/lib/blob-store';
 import type { AdminEvent, AdminEventFormData } from '@/types/admin';
 import type { RecurrenceFrequency } from '@/types/admin';
@@ -79,6 +80,8 @@ export async function POST(request: Request) {
     };
 
     await addAdminEvent(event);
+    revalidatePath('/calendar');
+    revalidatePath('/events');
     return NextResponse.json(event, { status: 201 });
   } catch {
     return NextResponse.json({ error: 'Failed to create event' }, { status: 500 });
@@ -99,6 +102,8 @@ export async function DELETE(request: Request) {
     } else {
       await deleteAdminEvent(id);
     }
+    revalidatePath('/calendar');
+    revalidatePath('/events');
     return NextResponse.json({ success: true });
   } catch {
     return NextResponse.json({ error: 'Failed to delete event' }, { status: 500 });

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import { getAdminPosts, addAdminPost, deleteAdminPost, updateAdminPost, getAdminPostById } from '@/lib/blob-store';
 import type { AdminBlogPost, AdminBlogPostFormData } from '@/types/admin';
 import { slugify } from '@/lib/utils';
@@ -71,6 +72,8 @@ export async function POST(request: Request) {
     };
 
     await addAdminPost(post);
+    revalidatePath('/bitcoin-association-switzerland');
+    revalidatePath(`/blog/${post.slug}`);
     return NextResponse.json(post, { status: 201 });
   } catch {
     return NextResponse.json({ error: 'Failed to create post' }, { status: 500 });
@@ -126,6 +129,8 @@ export async function PUT(request: Request) {
       return NextResponse.json({ error: 'Post not found' }, { status: 404 });
     }
 
+    revalidatePath('/bitcoin-association-switzerland');
+    revalidatePath(`/blog/${updated.slug}`);
     return NextResponse.json(updated);
   } catch {
     return NextResponse.json({ error: 'Failed to update post' }, { status: 500 });
@@ -139,7 +144,12 @@ export async function DELETE(request: Request) {
     if (!id) {
       return NextResponse.json({ error: 'Missing id parameter' }, { status: 400 });
     }
+    const existing = await getAdminPostById(id);
     await deleteAdminPost(id);
+    revalidatePath('/bitcoin-association-switzerland');
+    if (existing) {
+      revalidatePath(`/blog/${existing.slug}`);
+    }
     return NextResponse.json({ success: true });
   } catch {
     return NextResponse.json({ error: 'Failed to delete post' }, { status: 500 });

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
-import { getAdminPosts, addAdminPost, deleteAdminPost, updateAdminPost, getAdminPostById } from '@/lib/blob-store';
+import {
+  getAdminPosts,
+  addAdminPost,
+  deleteAdminPost,
+  updateAdminPost,
+  getAdminPostById,
+  invalidateAdminPostsCache,
+} from '@/lib/blob-store';
 import type { AdminBlogPost, AdminBlogPostFormData } from '@/types/admin';
 import { slugify } from '@/lib/utils';
 
@@ -72,6 +79,7 @@ export async function POST(request: Request) {
     };
 
     await addAdminPost(post);
+    invalidateAdminPostsCache();
     revalidatePath('/bitcoin-association-switzerland');
     revalidatePath(`/blog/${post.slug}`);
     return NextResponse.json(post, { status: 201 });
@@ -129,6 +137,7 @@ export async function PUT(request: Request) {
       return NextResponse.json({ error: 'Post not found' }, { status: 404 });
     }
 
+    invalidateAdminPostsCache();
     revalidatePath('/bitcoin-association-switzerland');
     revalidatePath(`/blog/${updated.slug}`);
     return NextResponse.json(updated);
@@ -146,6 +155,7 @@ export async function DELETE(request: Request) {
     }
     const existing = await getAdminPostById(id);
     await deleteAdminPost(id);
+    invalidateAdminPostsCache();
     revalidatePath('/bitcoin-association-switzerland');
     if (existing) {
       revalidatePath(`/blog/${existing.slug}`);

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import Header from '@/components/Header';
 import FooterSimple from '@/components/FooterSimple';
 import { getAdminPostBySlug } from '@/lib/blob-store';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 300;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/src/lib/blob-store.ts
+++ b/src/lib/blob-store.ts
@@ -1,10 +1,13 @@
-import { cache } from 'react';
-import { get, list, put } from '@vercel/blob';
+import { unstable_cache, revalidateTag } from 'next/cache';
+import { del, list, put } from '@vercel/blob';
 import type { AdminEvent, AdminBlogPost } from '@/types/admin';
-import { env } from '@/lib/env';
 
 const EVENTS_KEY = 'admin/events.json';
 const POSTS_KEY = 'admin/posts.json';
+
+const EVENTS_TAG = 'admin-events';
+const POSTS_TAG = 'admin-posts';
+const DATASET_VERSION_RETENTION = 2;
 
 interface StoredAdminEvent extends Omit<AdminEvent, 'category'> {
   category?: string;
@@ -18,109 +21,116 @@ function normalizeEventCategory(category: string | undefined): AdminEvent['categ
   return 'general';
 }
 
-async function readBlob<T>(key: string): Promise<T | null> {
+function getVersionedBlobPattern(key: string): { extension: string; prefix: string } {
+  const extensionMatch = /\.[^.]+$/.exec(key);
+  const extension = extensionMatch?.[0] ?? '';
+  const prefix = extension ? key.slice(0, -extension.length) : key;
+  return { extension, prefix };
+}
+
+function isVersionedBlobPath(pathname: string, key: string): boolean {
+  const { prefix, extension } = getVersionedBlobPattern(key);
+  return pathname.startsWith(`${prefix}-`) && pathname.endsWith(extension);
+}
+
+async function readVersionedBlob<T>(key: string): Promise<T | null> {
   try {
-    const result = await get(key, {
-      access: 'private',
-      token: env.BLOB_READ_WRITE_TOKEN,
-      useCache: false,
+    const versionedBlobs = await listVersionedBlobs(key);
+    if (versionedBlobs.length === 0) return null;
+
+    const latest = versionedBlobs.reduce((currentLatest, blob) => {
+      return new Date(blob.uploadedAt).getTime() > new Date(currentLatest.uploadedAt).getTime()
+        ? blob
+        : currentLatest;
     });
 
-    if (!result || result.statusCode !== 200) return null;
-    return await new Response(result.stream).json();
+    const response = await fetch(latest.url, { cache: 'no-store' });
+    if (!response.ok) return null;
+    return response.json() as Promise<T>;
   } catch {
     return null;
   }
 }
 
-async function readLegacyBlob<T>(key: string): Promise<T | null> {
-  try {
-    const prefix = key.replace(/\.[^.]+$/, '');
-    const { blobs } = await list({ prefix });
-    const legacyBlobs = blobs.filter((blob) => blob.pathname !== key);
-    if (legacyBlobs.length === 0) return null;
-
-    const latest = legacyBlobs
-      .slice()
-      .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
-
-    const res = await fetch(latest.url, { cache: 'no-store' });
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
-  }
-}
-
-async function writeBlob<T>(key: string, data: T): Promise<void> {
-  await put(key, JSON.stringify(data), {
-    access: 'private',
+async function writeVersionedBlob<T>(key: string, data: T): Promise<void> {
+  const newBlob = await put(key, JSON.stringify(data), {
+    access: 'public',
     contentType: 'application/json',
-    addRandomSuffix: false,
-    allowOverwrite: true,
+    addRandomSuffix: true,
   });
+
+  await pruneOldVersions(key, newBlob.url);
 }
 
-async function readEventsDataset(): Promise<StoredAdminEvent[]> {
-  const stableData = await readBlob<StoredAdminEvent[]>(EVENTS_KEY);
-  if (stableData) return stableData;
+async function listVersionedBlobs(key: string) {
+  const { prefix } = getVersionedBlobPattern(key);
+  const blobs = [];
+  let cursor: string | undefined;
 
-  const legacyData = await readLegacyBlob<StoredAdminEvent[]>(EVENTS_KEY);
-  if (!legacyData) return [];
+  do {
+    const page = await list({ prefix, cursor });
+    blobs.push(...page.blobs.filter((blob) => isVersionedBlobPath(blob.pathname, key)));
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
 
+  return blobs;
+}
+
+async function pruneOldVersions(key: string, newestBlobUrl: string): Promise<void> {
   try {
-    await writeBlob(EVENTS_KEY, legacyData);
+    const versionedBlobs = await listVersionedBlobs(key);
+    if (versionedBlobs.length <= DATASET_VERSION_RETENTION) return;
+
+    const sorted = versionedBlobs.slice().sort((a, b) => {
+      if (a.url === newestBlobUrl) return -1;
+      if (b.url === newestBlobUrl) return 1;
+      return new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime();
+    });
+
+    const staleUrls = sorted.slice(DATASET_VERSION_RETENTION).map((blob) => blob.url);
+    if (staleUrls.length > 0) {
+      await del(staleUrls);
+    }
   } catch {
-    // Legacy data was readable, so returning it is still the correct behavior.
+    // Cleanup is best-effort. Reads still use the latest version if pruning fails.
   }
-
-  return legacyData;
 }
-
-async function readPostsDataset(): Promise<AdminBlogPost[]> {
-  const stableData = await readBlob<AdminBlogPost[]>(POSTS_KEY);
-  if (stableData) return stableData;
-
-  const legacyData = await readLegacyBlob<AdminBlogPost[]>(POSTS_KEY);
-  if (!legacyData) return [];
-
-  try {
-    await writeBlob(POSTS_KEY, legacyData);
-  } catch {
-    // Legacy data was readable, so returning it is still the correct behavior.
-  }
-
-  return legacyData;
-}
-
-// --- Events ---
 
 async function getAdminEventsUncached(): Promise<AdminEvent[]> {
-  const events = await readEventsDataset();
+  const events = (await readVersionedBlob<StoredAdminEvent[]>(EVENTS_KEY)) ?? [];
   return events.map((event) => ({
     ...event,
     category: normalizeEventCategory(event.category),
   }));
 }
 
-const getAdminEventsCached = cache(async (): Promise<AdminEvent[]> => {
-  return getAdminEventsUncached();
-});
+const getAdminEventsCached = unstable_cache(
+  async (): Promise<AdminEvent[]> => getAdminEventsUncached(),
+  ['admin-events-dataset'],
+  {
+    tags: [EVENTS_TAG],
+    revalidate: false,
+  },
+);
 
 export async function getAdminEvents(): Promise<AdminEvent[]> {
   return getAdminEventsCached();
 }
 
+export function invalidateAdminEventsCache(): void {
+  revalidateTag(EVENTS_TAG, { expire: 0 });
+}
+
 export async function addAdminEvent(event: AdminEvent): Promise<void> {
   const events = await getAdminEventsUncached();
   events.push(event);
-  await writeBlob(EVENTS_KEY, events);
+  await writeVersionedBlob(EVENTS_KEY, events);
 }
 
 export async function deleteAdminEvent(id: string): Promise<void> {
   const events = await getAdminEventsUncached();
   const filtered = events.filter((e) => e.id !== id);
-  await writeBlob(EVENTS_KEY, filtered);
+  await writeVersionedBlob(EVENTS_KEY, filtered);
 }
 
 export async function excludeEventOccurrence(id: string, date: string): Promise<void> {
@@ -131,33 +141,40 @@ export async function excludeEventOccurrence(id: string, date: string): Promise<
   if (!event.excludedDates.includes(date)) {
     event.excludedDates.push(date);
   }
-  await writeBlob(EVENTS_KEY, events);
+  await writeVersionedBlob(EVENTS_KEY, events);
 }
-
-// --- Blog Posts ---
 
 async function getAdminPostsUncached(): Promise<AdminBlogPost[]> {
-  return [...await readPostsDataset()];
+  return (await readVersionedBlob<AdminBlogPost[]>(POSTS_KEY)) ?? [];
 }
 
-const getAdminPostsCached = cache(async (): Promise<AdminBlogPost[]> => {
-  return getAdminPostsUncached();
-});
+const getAdminPostsCached = unstable_cache(
+  async (): Promise<AdminBlogPost[]> => getAdminPostsUncached(),
+  ['admin-posts-dataset'],
+  {
+    tags: [POSTS_TAG],
+    revalidate: false,
+  },
+);
 
 export async function getAdminPosts(): Promise<AdminBlogPost[]> {
   return getAdminPostsCached();
 }
 
+export function invalidateAdminPostsCache(): void {
+  revalidateTag(POSTS_TAG, { expire: 0 });
+}
+
 export async function addAdminPost(post: AdminBlogPost): Promise<void> {
   const posts = await getAdminPostsUncached();
   posts.push(post);
-  await writeBlob(POSTS_KEY, posts);
+  await writeVersionedBlob(POSTS_KEY, posts);
 }
 
 export async function deleteAdminPost(id: string): Promise<void> {
   const posts = await getAdminPostsUncached();
   const filtered = posts.filter((p) => p.id !== id);
-  await writeBlob(POSTS_KEY, filtered);
+  await writeVersionedBlob(POSTS_KEY, filtered);
 }
 
 export async function getAdminPostBySlug(slug: string): Promise<AdminBlogPost | undefined> {
@@ -175,6 +192,6 @@ export async function updateAdminPost(id: string, updates: Partial<AdminBlogPost
   const index = posts.findIndex((p) => p.id === id);
   if (index === -1) return null;
   posts[index] = { ...posts[index], ...updates };
-  await writeBlob(POSTS_KEY, posts);
+  await writeVersionedBlob(POSTS_KEY, posts);
   return posts[index];
 }

--- a/src/lib/blob-store.ts
+++ b/src/lib/blob-store.ts
@@ -5,19 +5,10 @@ import { env } from '@/lib/env';
 
 const EVENTS_KEY = 'admin/events.json';
 const POSTS_KEY = 'admin/posts.json';
-const DATA_CACHE_TTL_MS = 60 * 1000;
 
 interface StoredAdminEvent extends Omit<AdminEvent, 'category'> {
   category?: string;
 }
-
-interface DatasetCacheEntry<T> {
-  value: T;
-  expiresAt: number;
-}
-
-let eventsCache: DatasetCacheEntry<StoredAdminEvent[]> | null = null;
-let postsCache: DatasetCacheEntry<AdminBlogPost[]> | null = null;
 
 function normalizeEventCategory(category: string | undefined): AdminEvent['category'] {
   if (category === 'roadshow') return 'conference';
@@ -30,7 +21,7 @@ function normalizeEventCategory(category: string | undefined): AdminEvent['categ
 async function readBlob<T>(key: string): Promise<T | null> {
   try {
     const result = await get(key, {
-      access: 'public',
+      access: 'private',
       token: env.BLOB_READ_WRITE_TOKEN,
       useCache: false,
     });
@@ -46,9 +37,10 @@ async function readLegacyBlob<T>(key: string): Promise<T | null> {
   try {
     const prefix = key.replace(/\.[^.]+$/, '');
     const { blobs } = await list({ prefix });
-    if (blobs.length === 0) return null;
+    const legacyBlobs = blobs.filter((blob) => blob.pathname !== key);
+    if (legacyBlobs.length === 0) return null;
 
-    const latest = blobs
+    const latest = legacyBlobs
       .slice()
       .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
 
@@ -60,66 +52,24 @@ async function readLegacyBlob<T>(key: string): Promise<T | null> {
   }
 }
 
-function getCachedValue<T>(entry: DatasetCacheEntry<T> | null): T | null {
-  if (!entry) return null;
-  if (Date.now() >= entry.expiresAt) return null;
-  return entry.value;
-}
-
-function setEventsCache(value: StoredAdminEvent[]): void {
-  eventsCache = {
-    value,
-    expiresAt: Date.now() + DATA_CACHE_TTL_MS,
-  };
-}
-
-function setPostsCache(value: AdminBlogPost[]): void {
-  postsCache = {
-    value,
-    expiresAt: Date.now() + DATA_CACHE_TTL_MS,
-  };
-}
-
-function clearEventsCache(): void {
-  eventsCache = null;
-}
-
-function clearPostsCache(): void {
-  postsCache = null;
-}
-
 async function writeBlob<T>(key: string, data: T): Promise<void> {
   await put(key, JSON.stringify(data), {
-    access: 'public',
+    access: 'private',
     contentType: 'application/json',
     addRandomSuffix: false,
     allowOverwrite: true,
-    // Keep the cache lifetime low for mutable JSON content.
-    cacheControlMaxAge: 60,
   });
 }
 
 async function readEventsDataset(): Promise<StoredAdminEvent[]> {
-  const cached = getCachedValue(eventsCache);
-  if (cached) return cached;
-
   const stableData = await readBlob<StoredAdminEvent[]>(EVENTS_KEY);
-  if (stableData) {
-    setEventsCache(stableData);
-    return stableData;
-  }
+  if (stableData) return stableData;
 
   const legacyData = await readLegacyBlob<StoredAdminEvent[]>(EVENTS_KEY);
-  if (!legacyData) {
-    setEventsCache([]);
-    return [];
-  }
-
-  setEventsCache(legacyData);
+  if (!legacyData) return [];
 
   try {
     await writeBlob(EVENTS_KEY, legacyData);
-    setEventsCache(legacyData);
   } catch {
     // Legacy data was readable, so returning it is still the correct behavior.
   }
@@ -128,26 +78,14 @@ async function readEventsDataset(): Promise<StoredAdminEvent[]> {
 }
 
 async function readPostsDataset(): Promise<AdminBlogPost[]> {
-  const cached = getCachedValue(postsCache);
-  if (cached) return cached;
-
   const stableData = await readBlob<AdminBlogPost[]>(POSTS_KEY);
-  if (stableData) {
-    setPostsCache(stableData);
-    return stableData;
-  }
+  if (stableData) return stableData;
 
   const legacyData = await readLegacyBlob<AdminBlogPost[]>(POSTS_KEY);
-  if (!legacyData) {
-    setPostsCache([]);
-    return [];
-  }
-
-  setPostsCache(legacyData);
+  if (!legacyData) return [];
 
   try {
     await writeBlob(POSTS_KEY, legacyData);
-    setPostsCache(legacyData);
   } catch {
     // Legacy data was readable, so returning it is still the correct behavior.
   }
@@ -176,17 +114,13 @@ export async function getAdminEvents(): Promise<AdminEvent[]> {
 export async function addAdminEvent(event: AdminEvent): Promise<void> {
   const events = await getAdminEventsUncached();
   events.push(event);
-  clearEventsCache();
   await writeBlob(EVENTS_KEY, events);
-  setEventsCache(events);
 }
 
 export async function deleteAdminEvent(id: string): Promise<void> {
   const events = await getAdminEventsUncached();
   const filtered = events.filter((e) => e.id !== id);
-  clearEventsCache();
   await writeBlob(EVENTS_KEY, filtered);
-  setEventsCache(filtered);
 }
 
 export async function excludeEventOccurrence(id: string, date: string): Promise<void> {
@@ -197,9 +131,7 @@ export async function excludeEventOccurrence(id: string, date: string): Promise<
   if (!event.excludedDates.includes(date)) {
     event.excludedDates.push(date);
   }
-  clearEventsCache();
   await writeBlob(EVENTS_KEY, events);
-  setEventsCache(events);
 }
 
 // --- Blog Posts ---
@@ -219,17 +151,13 @@ export async function getAdminPosts(): Promise<AdminBlogPost[]> {
 export async function addAdminPost(post: AdminBlogPost): Promise<void> {
   const posts = await getAdminPostsUncached();
   posts.push(post);
-  clearPostsCache();
   await writeBlob(POSTS_KEY, posts);
-  setPostsCache(posts);
 }
 
 export async function deleteAdminPost(id: string): Promise<void> {
   const posts = await getAdminPostsUncached();
   const filtered = posts.filter((p) => p.id !== id);
-  clearPostsCache();
   await writeBlob(POSTS_KEY, filtered);
-  setPostsCache(filtered);
 }
 
 export async function getAdminPostBySlug(slug: string): Promise<AdminBlogPost | undefined> {
@@ -247,8 +175,6 @@ export async function updateAdminPost(id: string, updates: Partial<AdminBlogPost
   const index = posts.findIndex((p) => p.id === id);
   if (index === -1) return null;
   posts[index] = { ...posts[index], ...updates };
-  clearPostsCache();
   await writeBlob(POSTS_KEY, posts);
-  setPostsCache(posts);
   return posts[index];
 }

--- a/src/lib/blob-store.ts
+++ b/src/lib/blob-store.ts
@@ -1,12 +1,23 @@
-import { put, list, del } from '@vercel/blob';
+import { cache } from 'react';
+import { get, list, put } from '@vercel/blob';
 import type { AdminEvent, AdminBlogPost } from '@/types/admin';
+import { env } from '@/lib/env';
 
 const EVENTS_KEY = 'admin/events.json';
 const POSTS_KEY = 'admin/posts.json';
+const DATA_CACHE_TTL_MS = 60 * 1000;
 
 interface StoredAdminEvent extends Omit<AdminEvent, 'category'> {
   category?: string;
 }
+
+interface DatasetCacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+let eventsCache: DatasetCacheEntry<StoredAdminEvent[]> | null = null;
+let postsCache: DatasetCacheEntry<AdminBlogPost[]> | null = null;
 
 function normalizeEventCategory(category: string | undefined): AdminEvent['category'] {
   if (category === 'roadshow') return 'conference';
@@ -18,93 +29,207 @@ function normalizeEventCategory(category: string | undefined): AdminEvent['categ
 
 async function readBlob<T>(key: string): Promise<T | null> {
   try {
-    // Strip extension for prefix search: addRandomSuffix inserts suffix before
-    // the extension, so "admin/events.json" becomes "admin/events-{suffix}.json"
-    // and won't match a prefix of "admin/events.json"
+    const result = await get(key, {
+      access: 'public',
+      token: env.BLOB_READ_WRITE_TOKEN,
+      useCache: false,
+    });
+
+    if (!result || result.statusCode !== 200) return null;
+    return await new Response(result.stream).json();
+  } catch {
+    return null;
+  }
+}
+
+async function readLegacyBlob<T>(key: string): Promise<T | null> {
+  try {
     const prefix = key.replace(/\.[^.]+$/, '');
     const { blobs } = await list({ prefix });
     if (blobs.length === 0) return null;
-    // Pick the most recently uploaded blob
-    const latest = blobs.sort(
-      (a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime()
-    )[0];
+
+    const latest = blobs
+      .slice()
+      .sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime())[0];
+
     const res = await fetch(latest.url, { cache: 'no-store' });
+    if (!res.ok) return null;
     return res.json();
   } catch {
     return null;
   }
 }
 
+function getCachedValue<T>(entry: DatasetCacheEntry<T> | null): T | null {
+  if (!entry) return null;
+  if (Date.now() >= entry.expiresAt) return null;
+  return entry.value;
+}
+
+function setEventsCache(value: StoredAdminEvent[]): void {
+  eventsCache = {
+    value,
+    expiresAt: Date.now() + DATA_CACHE_TTL_MS,
+  };
+}
+
+function setPostsCache(value: AdminBlogPost[]): void {
+  postsCache = {
+    value,
+    expiresAt: Date.now() + DATA_CACHE_TTL_MS,
+  };
+}
+
+function clearEventsCache(): void {
+  eventsCache = null;
+}
+
+function clearPostsCache(): void {
+  postsCache = null;
+}
+
 async function writeBlob<T>(key: string, data: T): Promise<void> {
-  // Write new data FIRST (with random suffix to avoid conflicts)
-  const newBlob = await put(key, JSON.stringify(data), {
+  await put(key, JSON.stringify(data), {
     access: 'public',
     contentType: 'application/json',
-    addRandomSuffix: true,
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    // Keep the cache lifetime low for mutable JSON content.
+    cacheControlMaxAge: 60,
   });
-  // Then clean up old blobs (safe: new data is already persisted)
-  try {
-    const prefix = key.replace(/\.[^.]+$/, '');
-    const { blobs } = await list({ prefix });
-    for (const blob of blobs) {
-      if (blob.url !== newBlob.url) {
-        await del(blob.url);
-      }
-    }
-  } catch {
-    // Cleanup failure is non-critical — data is safe
+}
+
+async function readEventsDataset(): Promise<StoredAdminEvent[]> {
+  const cached = getCachedValue(eventsCache);
+  if (cached) return cached;
+
+  const stableData = await readBlob<StoredAdminEvent[]>(EVENTS_KEY);
+  if (stableData) {
+    setEventsCache(stableData);
+    return stableData;
   }
+
+  const legacyData = await readLegacyBlob<StoredAdminEvent[]>(EVENTS_KEY);
+  if (!legacyData) {
+    setEventsCache([]);
+    return [];
+  }
+
+  setEventsCache(legacyData);
+
+  try {
+    await writeBlob(EVENTS_KEY, legacyData);
+    setEventsCache(legacyData);
+  } catch {
+    // Legacy data was readable, so returning it is still the correct behavior.
+  }
+
+  return legacyData;
+}
+
+async function readPostsDataset(): Promise<AdminBlogPost[]> {
+  const cached = getCachedValue(postsCache);
+  if (cached) return cached;
+
+  const stableData = await readBlob<AdminBlogPost[]>(POSTS_KEY);
+  if (stableData) {
+    setPostsCache(stableData);
+    return stableData;
+  }
+
+  const legacyData = await readLegacyBlob<AdminBlogPost[]>(POSTS_KEY);
+  if (!legacyData) {
+    setPostsCache([]);
+    return [];
+  }
+
+  setPostsCache(legacyData);
+
+  try {
+    await writeBlob(POSTS_KEY, legacyData);
+    setPostsCache(legacyData);
+  } catch {
+    // Legacy data was readable, so returning it is still the correct behavior.
+  }
+
+  return legacyData;
 }
 
 // --- Events ---
 
-export async function getAdminEvents(): Promise<AdminEvent[]> {
-  const events = (await readBlob<StoredAdminEvent[]>(EVENTS_KEY)) || [];
+async function getAdminEventsUncached(): Promise<AdminEvent[]> {
+  const events = await readEventsDataset();
   return events.map((event) => ({
     ...event,
     category: normalizeEventCategory(event.category),
   }));
 }
 
+const getAdminEventsCached = cache(async (): Promise<AdminEvent[]> => {
+  return getAdminEventsUncached();
+});
+
+export async function getAdminEvents(): Promise<AdminEvent[]> {
+  return getAdminEventsCached();
+}
+
 export async function addAdminEvent(event: AdminEvent): Promise<void> {
-  const events = await getAdminEvents();
+  const events = await getAdminEventsUncached();
   events.push(event);
+  clearEventsCache();
   await writeBlob(EVENTS_KEY, events);
+  setEventsCache(events);
 }
 
 export async function deleteAdminEvent(id: string): Promise<void> {
-  const events = await getAdminEvents();
+  const events = await getAdminEventsUncached();
   const filtered = events.filter((e) => e.id !== id);
+  clearEventsCache();
   await writeBlob(EVENTS_KEY, filtered);
+  setEventsCache(filtered);
 }
 
 export async function excludeEventOccurrence(id: string, date: string): Promise<void> {
-  const events = await getAdminEvents();
+  const events = await getAdminEventsUncached();
   const event = events.find((e) => e.id === id);
   if (!event) return;
   if (!event.excludedDates) event.excludedDates = [];
   if (!event.excludedDates.includes(date)) {
     event.excludedDates.push(date);
   }
+  clearEventsCache();
   await writeBlob(EVENTS_KEY, events);
+  setEventsCache(events);
 }
 
 // --- Blog Posts ---
 
+async function getAdminPostsUncached(): Promise<AdminBlogPost[]> {
+  return [...await readPostsDataset()];
+}
+
+const getAdminPostsCached = cache(async (): Promise<AdminBlogPost[]> => {
+  return getAdminPostsUncached();
+});
+
 export async function getAdminPosts(): Promise<AdminBlogPost[]> {
-  return (await readBlob<AdminBlogPost[]>(POSTS_KEY)) || [];
+  return getAdminPostsCached();
 }
 
 export async function addAdminPost(post: AdminBlogPost): Promise<void> {
-  const posts = await getAdminPosts();
+  const posts = await getAdminPostsUncached();
   posts.push(post);
+  clearPostsCache();
   await writeBlob(POSTS_KEY, posts);
+  setPostsCache(posts);
 }
 
 export async function deleteAdminPost(id: string): Promise<void> {
-  const posts = await getAdminPosts();
+  const posts = await getAdminPostsUncached();
   const filtered = posts.filter((p) => p.id !== id);
+  clearPostsCache();
   await writeBlob(POSTS_KEY, filtered);
+  setPostsCache(filtered);
 }
 
 export async function getAdminPostBySlug(slug: string): Promise<AdminBlogPost | undefined> {
@@ -118,10 +243,12 @@ export async function getAdminPostById(id: string): Promise<AdminBlogPost | unde
 }
 
 export async function updateAdminPost(id: string, updates: Partial<AdminBlogPost>): Promise<AdminBlogPost | null> {
-  const posts = await getAdminPosts();
+  const posts = await getAdminPostsUncached();
   const index = posts.findIndex((p) => p.id === id);
   if (index === -1) return null;
   posts[index] = { ...posts[index], ...updates };
+  clearPostsCache();
   await writeBlob(POSTS_KEY, posts);
+  setPostsCache(posts);
   return posts[index];
 }


### PR DESCRIPTION
## What changed
- replaced the old single-prefix blob read/write flow with versioned blob listing, latest-version reads, and best-effort retention pruning
- added dataset-level caching for admin events and posts with explicit cache invalidation hooks
- revalidated affected public routes after admin post and event mutations
- switched blog post pages from fully dynamic rendering to timed revalidation

## Why
The previous blob access pattern did extra Blob operations and relied on broad prefix matching with immediate cleanup. This refactor tightens version selection, reduces repeated reads through caching, and makes cache invalidation explicit after writes.

## Impact
- fewer Blob operations for admin content reads
- safer retention of recent dataset versions
- public blog and event pages stay in sync after admin mutations without forcing every request to be dynamic

## Validation
- reviewed git diff against `main`
- confirmed branch is 3 commits ahead of `main` and 0 behind
- `git diff --check` passes
- no automated tests or CI checks were run from this environment